### PR TITLE
Fixed a crashing bug and a deadlock bug

### DIFF
--- a/core/slave.tpp
+++ b/core/slave.tpp
@@ -158,7 +158,12 @@ int Slave<TaskT, AggregatorT>::set_resp(ibinstream & m, obinstream & um)//return
 		int tgt;
 		um >> tgt;
 		TaskVec remote_tasks;
+		compute_lock_.lock();
 		task_pipeline_.pq_pop_front_to_remote(remote_tasks);
+		compute_lock_.unlock();
+		// After pq_pop_front_to_remote, TASK_IN_DISK_NUM will decrease
+		// Thus, notify the conpute_cond_ for run_to_no_task()
+		compute_cond_.notify_one();
 		int num = remote_tasks.size();
 		m << num;
 		for(int i = 0; i < num; i++)

--- a/core/task_sorter.tpp
+++ b/core/task_sorter.tpp
@@ -215,13 +215,16 @@ void TaskSorter<TaskT>::last_merge_seed_tasks(PQue& pque, int fnum, int level)
 	{
 		vector<KTpair> tasks;
 		int size = buffer.size() / 2;
-		for(int i = 0 ; i < size; i ++)
+		if (size != 0)
 		{
-			tasks.push_back(buffer.front());
-			buffer.pop();
+			for(int i = 0 ; i < size; i ++)
+			{
+				tasks.push_back(buffer.front());
+				buffer.pop();
+			}
+			pque.add_block(tasks);
+			tasks.clear();
 		}
-		pque.add_block(tasks);
-		tasks.clear();
 
 		size = buffer.size();
 		for(int i = 0 ; i < size; i ++)


### PR DESCRIPTION
This PR contains 2 commits.

### Check the vector size to avoid empty tasks vector

In TaskSorter::last_merge_seed_tasks(), guarantee that ```tasks``` vector is not empty before passing it to ```pque.add_block(tasks)```, since ```add_block(tasks)``` calls ```add_fmeta(tasks)``` in priority_queue.tpp, and ```add_fmeta(tasks)``` will try to access the first and the last element in ```tasks```.

### Fixed the deadlock by calling notify_one() after responding stealing requests

Before this PR, the conditional variable in ```run_to_no_task()``` is notified when a tasks is finished.

When popping tasks to remote workers, ```task_pipeline_.pq_pop_front_to_remote(remote_tasks)``` is invoked, and in this function the ```TASK_NUM_IN_DISK``` will decreases. If no tasks remain on the worker after this decrease, the conditional variable waited in ```run_to_no_task()``` will never be notified, and a deadlock condition will occur.

Thus, after this PR, the conditional variable will be notified when ```task_pipeline_.pq_pop_front_to_remote(remote_tasks)``` is finished.