### PR TITLE
[bug fix] Missing type conversion in the graph partition module.

### DIFF
--- a/partition/BDGPartitioner.tpp
+++ b/partition/BDGPartitioner.tpp
@@ -186,7 +186,7 @@ void BDGPartitioner<BDGPartVertexT>::partition(vector<blockInfo> & blocks_info, 
 			cmIter = countmap[j].find(cur.color);
 			if (cmIter != countmap[j].end())
 			{
-				priority = cmIter->second * (1 - assigned[j] / capacity);  //calculate the priority of each work for current block
+				priority = cmIter->second * (1 - assigned[j] / (double)capacity);  //calculate the priority of each work for current block
 			}
 			if ((priority > max) && (assigned[j] + cur.size <= capacity))
 			{


### PR DESCRIPTION
The integer type should be converted to a double type in the division operation.